### PR TITLE
Increased the number of semaphores

### DIFF
--- a/greenplum/gpdb-segments_within_single_host.cf.json
+++ b/greenplum/gpdb-segments_within_single_host.cf.json
@@ -125,6 +125,11 @@
                                     ]]
                                 }
                             }
+                        },
+                        "commands": {
+                            "c-01-increase-semaphores": {
+                                "command": "sudo sysctl -w \"kernel.sem=250 512000 200 2048\""
+                            }
                         }
                     },
                     "install_packages": {

--- a/greenplum/gpdb-segments_within_single_host.cf.json
+++ b/greenplum/gpdb-segments_within_single_host.cf.json
@@ -124,11 +124,13 @@
                                         "kernel.shmall = 1099511627776", "\n"
                                     ]]
                                 }
-                            }
-                        },
-                        "commands": {
-                            "c-01-increase-semaphores": {
-                                "command": "sudo sysctl -w \"kernel.sem=250 512000 200 2048\""
+                            },
+                            "/etc/sysctl.d/10-gpdb-sem.conf": {
+                                "content": {
+                                    "Fn::Join": ["", [
+                                        "kernel.sem = 250 512000 200 2048", "\n"
+                                  ]]
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
With more than 2 segments the default number of semaphores is not enough
to initialize GreenPlum, so the system is configured to the recommended
values from Pivotal.
